### PR TITLE
[김동규] #9 유저 로그아웃 기능 테스트코드 작성 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ipython==8.4.0
 python-dotenv==0.20.0
 drf-yasg==1.20.3
 bcrypt==3.2.0
+cffi==1.15.1

--- a/users/tests/tests_signout.py
+++ b/users/tests/tests_signout.py
@@ -1,0 +1,225 @@
+import json
+
+from rest_framework.test             import APITestCase, APIClient
+from rest_framework_simplejwt.tokens import OutstandingToken, BlacklistedToken
+
+from unittest.mock import patch
+from unittest      import mock
+
+from users.models import User
+
+
+class UserSignOutTest(APITestCase):
+    
+    maxDiff = None
+    
+    @classmethod
+    def setUpTestData(cls):
+        cls.f_user = User.objects\
+                         .create(
+                             email    = 'user@example.com',
+                             nickname = 'user',
+                             kakao_id = 12345678910
+                         )
+                         
+        cls.s_user = User.objects\
+                         .create(
+                             email    = 'test@example.com',
+                             nickname = 'test',
+                             kakao_id = 123456789
+                         )
+           
+        cls.f_client = APIClient()
+        cls.f_client.force_authenticate(user=cls.f_user)        
+            
+    @patch('core.utils.get_obj_n_check_err.requests')
+    def test_success_user_signout(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 12345678910,
+                    'kakao_account': {
+                        'email'  : 'user@example.com',
+                        'profile': {
+                            'nickname': 'user'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+        
+        user = User.objects\
+                   .get(email='user@example.com')
+                   
+        refresh = OutstandingToken.objects\
+                                  .get(user=user)
+        
+        data = {
+            'refesh_token': refresh.token
+        }
+        
+        response = self.f_client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        blacklist_token = BlacklistedToken.objects\
+                                          .get(token_id=refresh.id)
+                                          
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(refresh.id, blacklist_token.token_id)
+        
+    @patch('core.utils.get_obj_n_check_err.requests')
+    def test_fail_user_signout_due_to_unauthorized_user(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 12345678910,
+                    'kakao_account': {
+                        'email'  : 'user@example.com',
+                        'profile': {
+                            'nickname': 'user'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+        
+        user = User.objects\
+                   .get(email='user@example.com')
+                   
+        refresh = OutstandingToken.objects\
+                                  .get(user=user)
+        
+        data = {
+            'refesh_token': refresh.token
+        }
+        
+        response = self.client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '자격 인증데이터(authentication credentials)가 제공되지 않았습니다.'
+            }
+        )
+        
+    def test_fail_user_signout_due_to_refresh_token_required(self):
+        data = {}
+        
+        response = self.f_client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '유효하지 않거나 만료된 토큰입니다.'
+            }
+        )
+        
+    def test_fail_user_signout_due_to_refresh_token_mismatch(self):
+        data = {
+            'refesh_token': 'fake token'
+        }
+        
+        response = self.f_client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '유효하지 않거나 만료된 토큰입니다.'
+            }
+        )
+        
+    @patch('core.utils.get_obj_n_check_err.requests')
+    def test_fail_user_signout_due_to_token_type_mismatch(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 12345678910,
+                    'kakao_account': {
+                        'email'  : 'user@example.com',
+                        'profile': {
+                            'nickname': 'user'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+                       
+        access = response.json()['access']
+        
+        data = {
+            'refesh_token': access
+        }
+        
+        response = self.f_client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '유효하지 않거나 만료된 토큰입니다.'
+            }
+        )
+        
+    @patch('core.utils.get_obj_n_check_err.requests')
+    def test_fail_user_signout_due_to_not_own_refresh_token(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 123456789,
+                    'kakao_account': {
+                        'email'  : 'test@example.com',
+                        'profile': {
+                            'nickname': 'test'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+        
+        user = User.objects\
+                   .get(email='test@example.com')
+                   
+        refresh = OutstandingToken.objects\
+                                  .get(user=user)
+        
+        data = {
+            'refesh_token': refresh.token
+        }
+        
+        response = self.f_client\
+                       .post('/api/users/signout', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '유저의 토큰정보가 유효하지 않습니다.'
+            }
+        )


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #9 
- 유저 로그아웃 기능 테스트코드 작성

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 유저 로그아웃 기능 테스트코드 작성
- 성공/실패 케이스를 분류하여 테스트코드 작성
- 데이터 mocking을 활용하여 실제 카카오 유저정보 요청을 하지 않는 독립적인 테스트코드 작성

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->
<img width="1008" alt="스크린샷 2022-09-14 09 46 13" src="https://user-images.githubusercontent.com/89829943/190034321-bdea4268-d02f-475d-8e1c-6f7ef1e66342.png">


