### PR TITLE
[김동규] #9 유저 토큰 재발급 기능 테스트코드 작성

### DIFF
--- a/users/tests/tests_refesh_token.py
+++ b/users/tests/tests_refesh_token.py
@@ -1,0 +1,150 @@
+import json
+
+from rest_framework.test             import APITestCase
+from rest_framework_simplejwt.tokens import OutstandingToken
+
+from unittest.mock import patch
+from unittest      import mock
+
+from users.models  import User
+
+
+class UserRefreshTokenTest(APITestCase):
+    
+    maxDiff = None
+    
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create(
+            email    = 'user@example.com',
+            nickname = 'user',
+            kakao_id = 12345678910
+        )
+    
+    @patch('core.utils.get_obj_n_check_err.requests')    
+    def test_success_user_refresh_token(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 12345678910,
+                    'kakao_account': {
+                        'email'  : 'user@example.com',
+                        'profile': {
+                            'nickname': 'user'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+        
+        user = User.objects\
+                   .get(email='user@example.com')
+                   
+        refresh = OutstandingToken.objects\
+                                  .get(user=user)
+                                  
+        data = {
+            'refresh': refresh.token
+        }
+        
+        response = self.client\
+                       .post('/api/users/token-refresh', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('access', response.json())
+        self.assertNotIn('refresh', response.json())
+        
+    def test_fail_user_refresh_token_due_to_refresh_token_required(self):
+        data = {}
+        
+        response = self.client\
+                       .post('/api/users/token-refresh', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'refresh': [
+                    '이 필드는 필수 항목입니다.'
+                ]
+            }
+        )
+        
+    def test_fail_user_refresh_token_due_to_invalid_refresh_token(self):
+        data = {
+            'refresh': ' '
+        }
+        
+        response = self.client\
+                       .post('/api/users/token-refresh', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'refresh': [
+                    '이 필드는 blank일 수 없습니다.'
+                ]
+            }
+        )
+    
+    def test_fail_user_refresh_token_due_to_refresh_token_mismatch(self):
+        data = {
+            'refresh': 'fake token'
+        }
+        
+        response = self.client\
+                       .post('/api/users/token-refresh', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '유효하지 않거나 만료된 토큰',
+                'code'  : 'token_not_valid'
+            }
+        )
+    
+    @patch('core.utils.get_obj_n_check_err.requests')        
+    def test_fail_user_refresh_token_due_to_token_type_mismatch(self, mocked_requests):
+        
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 12345678910,
+                    'kakao_account': {
+                        'email'  : 'user@example.com',
+                        'profile': {
+                            'nickname': 'user'
+                        }
+                    }
+                }
+                
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        headers  = {'HTTP_Authorization': 'kakao token'}
+        response = self.client\
+                       .get('/api/users/kakao-signin', **headers, content_type='application/json')
+                       
+        access = response.json()['access']
+        
+        data = {
+            'refresh': access
+        }
+        
+        response = self.client\
+                       .post('/api/users/token-refresh', data=json.dumps(data), content_type='application/json')
+                       
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '잘못된 토큰 타입',
+                'code'  : 'token_not_valid'
+            }
+        )

--- a/users/tests/tests_signout.py
+++ b/users/tests/tests_signout.py
@@ -6,7 +6,7 @@ from rest_framework_simplejwt.tokens import OutstandingToken, BlacklistedToken
 from unittest.mock import patch
 from unittest      import mock
 
-from users.models import User
+from users.models  import User
 
 
 class UserSignOutTest(APITestCase):
@@ -60,7 +60,7 @@ class UserSignOutTest(APITestCase):
                                   .get(user=user)
         
         data = {
-            'refesh_token': refresh.token
+            'refresh_token': refresh.token
         }
         
         response = self.f_client\
@@ -100,7 +100,7 @@ class UserSignOutTest(APITestCase):
                                   .get(user=user)
         
         data = {
-            'refesh_token': refresh.token
+            'refresh_token': refresh.token
         }
         
         response = self.client\
@@ -130,7 +130,7 @@ class UserSignOutTest(APITestCase):
         
     def test_fail_user_signout_due_to_refresh_token_mismatch(self):
         data = {
-            'refesh_token': 'fake token'
+            'refresh_token': 'fake token'
         }
         
         response = self.f_client\
@@ -168,7 +168,7 @@ class UserSignOutTest(APITestCase):
         access = response.json()['access']
         
         data = {
-            'refesh_token': access
+            'refresh_token': access
         }
         
         response = self.f_client\
@@ -210,7 +210,7 @@ class UserSignOutTest(APITestCase):
                                   .get(user=user)
         
         data = {
-            'refesh_token': refresh.token
+            'refresh_token': refresh.token
         }
         
         response = self.f_client\

--- a/users/views/signout.py
+++ b/users/views/signout.py
@@ -13,9 +13,9 @@ class UserSignOutView(APIView):
     
     post_params = openapi.Schema(
         type       = openapi.TYPE_OBJECT,
-        required   = ['refesh_token'],
+        required   = ['refresh_token'],
         properties = {
-            'refesh_token': openapi.Schema(type=openapi.TYPE_STRING, description='string'),
+            'refresh_token': openapi.Schema(type=openapi.TYPE_STRING, description='string'),
         }
     )
     
@@ -24,7 +24,7 @@ class UserSignOutView(APIView):
         user = request.user
         
         try:
-            refresh = RefreshToken(request.data['refesh_token'])
+            refresh = RefreshToken(request.data['refresh_token'])
         except:
             return Response({'detail': '유효하지 않거나 만료된 토큰입니다.'}, status=400)
         


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #9 
- 유저 토큰 재발급 기능 테스트코드 작성

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 유저 토큰 재발급 기능 테스트코드 작성
- 성공/실패 케이스를 분류하여 테스트코드 작성
- 데이터 mocking을 활용하여 실제 카카오 유저정보 요청을 하지 않는 독립적인 테스트코드 작성

# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->
<img width="913" alt="스크린샷 2022-09-16 09 12 21" src="https://user-images.githubusercontent.com/89829943/190530053-564c4208-eb12-4fa7-a81b-fa6fe5671738.png">
